### PR TITLE
Simplify Svg usage

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -62,39 +62,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.6"
-  flutter_svg_provider:
-    dependency: transitive
-    description:
-      name: flutter_svg_provider
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.13.5"
-  http_parser:
-    dependency: transitive
-    description:
-      name: http_parser
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
@@ -108,7 +80,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
@@ -155,7 +127,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -169,7 +141,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -190,21 +162,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.14"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   xml:
     dependency: transitive
     description:

--- a/lib/circle_flags.dart
+++ b/lib/circle_flags.dart
@@ -1,21 +1,18 @@
 library circle_flags;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:flutter_svg/parser.dart';
 
 /// a rounded flag
 class CircleFlag extends StatelessWidget {
   final String countryCode;
   final double? size;
-  final SvgParser svgParser = SvgParser();
-  late final String assetName;
+  final String assetName;
 
-  CircleFlag(this.countryCode, {Key? key, this.size}) : super(key: key) {
-    assetName =
-    'packages/circle_flags/assets/svg/${countryCode.toLowerCase()}.svg';
-  }
+  CircleFlag(this.countryCode, {Key? key, this.size})
+      : assetName =
+            'packages/circle_flags/assets/svg/${countryCode.toLowerCase()}.svg',
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -24,53 +21,11 @@ class CircleFlag extends StatelessWidget {
     return SizedBox(
       width: size,
       height: size,
-      child: FutureBuilder(
-        future: _isAssetNameValidSvg(),
-        builder: (context, AsyncSnapshot<bool> snapshot) {
-          if (snapshot.hasData && snapshot.data == true) {
-            return SvgPicture.asset(
-              assetName,
-              width: size,
-              height: size,
-            );
-          }
-
-          if (snapshot.hasError) {
-            return Container(
-              width: size,
-              height: size,
-              padding: const EdgeInsets.all(8),
-              decoration: const BoxDecoration(
-                shape: BoxShape.circle,
-                color: Colors.grey,
-              ),
-              child: Text(
-                countryCode,
-                textAlign: TextAlign.center,
-                style: const TextStyle(
-                  color: Colors.white,
-                ),
-              ),
-            );
-          }
-
-          return SizedBox(
-            width: size,
-            height: size,
-            child: const CircularProgressIndicator(),
-          );
-        },
+      child: SvgPicture.asset(
+        assetName,
+        width: size,
+        height: size,
       ),
     );
-  }
-
-  Future<bool> _isAssetNameValidSvg() async {
-    try {
-      final svgString = await rootBundle.loadString(assetName);
-      await svgParser.parse(svgString);
-      return true;
-    } catch (e) {
-      throw Exception('Error loading asset $assetName');
-    }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -55,39 +55,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.6"
-  flutter_svg_provider:
-    dependency: "direct main"
-    description:
-      name: flutter_svg_provider
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.13.5"
-  http_parser:
-    dependency: transitive
-    description:
-      name: http_parser
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
@@ -101,7 +73,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
@@ -148,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -162,7 +134,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -183,21 +155,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.14"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^1.1.6
-  flutter_svg_provider: ^1.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hello,
I come to this package because I use phone_form_field.

The last version of this package with the SVG implementation has several issues for me:
- `_isAssetNameValidSvg` means that the SVG files are loaded and parsed twice.
- The circular progress indicator and error widget seems very opinionated. Why no just rely on the behaviour of the svg widget?
- The usage of `rootBundle` is not recommended. It should use `DefaultAssetBundle.of(context)` instead. So we can override it in our testing.
- `package:flutter_svg_provider` is added as a dependency while it is not used.

In this PR, I propose to come back at a simpler implementation.