### PR TITLE
fixed: widget tests deadlocks. more tests are added.

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -43,6 +43,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.16.0"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
   fake_async:
     dependency: transitive
     description:
@@ -88,13 +95,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
@@ -108,7 +108,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -169,7 +169,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -190,7 +190,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.14"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:
@@ -198,13 +198,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   xml:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,6 +36,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.16.0"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
   fake_async:
     dependency: transitive
     description:
@@ -81,13 +88,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
@@ -101,7 +101,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -162,7 +162,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -183,7 +183,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.14"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:
@@ -191,13 +191,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  universal_io:
+    dependency: "direct main"
+    description:
+      name: universal_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: circle_flags
 description: A collection of roundd flags
-version: 1.0.0
+version: 1.0.0+1
 repository: https://github.com/cedvdb/flutter_circle_flags
 
 environment:
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   flutter_svg: ^1.1.6
   flutter_svg_provider: ^1.0.3
+  universal_io: any
 
 dev_dependencies:
   flutter_test:

--- a/test/circle_flags_test.dart
+++ b/test/circle_flags_test.dart
@@ -1,8 +1,76 @@
 import 'package:circle_flags/circle_flags.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  widget(tester) => MaterialApp(
+        home: Scaffold(
+          body: Builder(builder: (context) {
+            return Column(
+              children: [
+                CircleFlag('US'),
+                OutlinedButton(
+                    onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(vertical: 8.0),
+                              child: Text('CLICKED'),
+                            ),
+                          ),
+                        ),
+                    child: Text('CLICK ME'))
+              ],
+            );
+          }),
+        ),
+      );
+
   testWidgets('renders', (tester) async {
     await tester.pumpWidget(CircleFlag('US'));
+  });
+
+  group('able to use in complex tests in async and non-async contexts', () {
+    stepAsync(tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(widget(tester));
+      });
+
+      await tester.runAsync(() async {
+        await tester.tap(find.text('CLICK ME'));
+      });
+
+      await tester.pumpAndSettle();
+    }
+
+    stepSync(tester) async {
+      await tester.pumpWidget(widget(tester));
+      await tester.tap(find.text('CLICK ME'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('Async test 1', (tester) async {
+      await stepAsync(tester);
+      expect(find.text('CLICKED'), findsOneWidget,
+          reason: 'OK in first async step');
+    });
+
+    testWidgets('Async test 2', (tester) async {
+      await stepAsync(tester);
+      expect(find.text('CLICKED'), findsOneWidget,
+          reason: 'OK in second async step');
+    });
+
+    testWidgets('Sync test 1', (tester) async {
+      await stepSync(tester);
+      expect(find.text('CLICKED'), findsOneWidget,
+          reason: 'OK in first sync step');
+    });
+
+    testWidgets('Sync test 2', (tester) async {
+      await stepSync(tester);
+      expect(find.text('CLICKED'), findsOneWidget,
+          reason: 'OK in second sync step');
+    });
   });
 }


### PR DESCRIPTION
fixed bugs like this when testing apps using CircleFlag:

```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following assertion was thrown running a test:
pumpAndSettle timed out

When the exception was thrown, this was the stack:
#0      WidgetTester.pumpAndSettle.<anonymous closure> (package:flutter_test/src/widget_tester.dart:673:11)
<asynchronous suspension>
<asynchronous suspension>
(elided one frame from package:stack_trace)
```